### PR TITLE
Update Electrum endpoints from address to scripthash - fix tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,4 @@
 
 !dist/
-src/
-test/
-tsconfig.json
 tslint.json
 examples/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ install:
 script:
   - yarn lint
   - yarn test
+before_script :
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mocha": "^5.1.0",
     "ts-node": "^5.0.1",
     "tslint-kaplankomputing": "^1.0.0",
-    "typescript": "^2.8.1"
+    "typescript": "^3.1.1"
   },
   "dependencies": {
     "@types/chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "json-rpc-tls": "^1.2.2"
   },
   "scripts": {
+    "install": "npm run compile",
     "compile": "tsc",
     "compile:watch": "tsc -w",
     "prepublish": "yarn compile",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "electrum-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/index.js",
-  "description": "Complete ibrary for communicating with Electrum servers with support for all methods",
+  "description": "Complete library for communicating with Electrum servers with support for most methods",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:kaplanmaxe/electrum-api.git",
   "author": "Max Kaplan <kaplanmaxe3@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
     "@types/node": "^9.6.5",
+    "bitcoinjs-lib": "^5.1.7",
     "json-rpc-tls": "^1.2.2"
   },
   "scripts": {

--- a/src/blockchain/index.ts
+++ b/src/blockchain/index.ts
@@ -2,15 +2,6 @@ import { ElectrumUtil } from '../util';
 import { IElectrumRequestBody } from '../';
 
 class Blockchain {
-  static async numBlocksSubscribe(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.numblocks.subscribe',
-      params: request.params || [],
-    });
-    return result;
-  }
 
   static async headersSubscribe(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
@@ -22,71 +13,51 @@ class Blockchain {
     return result;
   }
 
-  static async addressSubscribe(request: IElectrumRequestBody) {
+  static async ScriptHashSubscribe(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.address.subscribe',
+      method: 'blockchain.scripthash.subscribe',
       params: request.params || [],
     });
     return result;
   }
 
-  static async addressGetHistory(request: IElectrumRequestBody) {
+  static async ScriptHashGetHistory(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.address.get_history',
+      method: 'blockchain.scripthash.get_history',
       params: request.params || [],
     });
     return result;
   }
 
-  static async addressGetMempool(request: IElectrumRequestBody) {
+  static async ScriptHashGetMempool(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.address.get_mempool',
+      method: 'blockchain.scripthash.get_mempool',
       params: request.params || [],
     });
     return result;
   }
 
-  static async addressGetBalance(request: IElectrumRequestBody) {
+  static async ScriptHashGetBalance(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.address.get_balance',
+      method: 'blockchain.scripthash.get_balance',
       params: request.params || [],
     });
     return result;
   }
 
-  static async addressGetProof(request: IElectrumRequestBody) {
+  static async ScriptHashListUnspent(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.address.get_proof',
-      params: request.params || [],
-    });
-    return result;
-  }
-
-  static async addressListUnspent(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.address.listunspent',
-      params: request.params || [],
-    });
-    return result;
-  }
-
-  static async utxoGetAddress(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.utxo.get_address',
+      method: 'blockchain.scripthash.listunspent',
       params: request.params || [],
     });
     return result;
@@ -96,7 +67,7 @@ class Blockchain {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.block.get_header',
+      method: 'blockchain.block.header',
       params: request.params || [],
     });
     return result;

--- a/src/blockchain/index.ts
+++ b/src/blockchain/index.ts
@@ -13,7 +13,7 @@ class Blockchain {
     return result;
   }
 
-  static async ScriptHashSubscribe(request: IElectrumRequestBody) {
+  static async scriptHashSubscribe(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
@@ -23,7 +23,7 @@ class Blockchain {
     return result;
   }
 
-  static async ScriptHashGetHistory(request: IElectrumRequestBody) {
+  static async scriptHashGetHistory(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
@@ -33,7 +33,7 @@ class Blockchain {
     return result;
   }
 
-  static async ScriptHashGetMempool(request: IElectrumRequestBody) {
+  static async scriptHashGetMempool(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
@@ -43,7 +43,7 @@ class Blockchain {
     return result;
   }
 
-  static async ScriptHashGetBalance(request: IElectrumRequestBody) {
+  static async scriptHashGetBalance(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
@@ -53,7 +53,7 @@ class Blockchain {
     return result;
   }
 
-  static async ScriptHashListUnspent(request: IElectrumRequestBody) {
+  static async scriptHashListUnspent(request: IElectrumRequestBody) {
     const result = await ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { TLSSocket  } from 'tls';
 import { Server } from './server';
 import { Blockchain } from './blockchain';
+import { Utils } from './util';
 
 export interface IElectrumRequestBody {
   socket: TLSSocket;
@@ -11,4 +12,5 @@ export interface IElectrumRequestBody {
 export {
   Server,
   Blockchain,
+  Utils
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export interface IElectrumRequestBody {
 export {
   Server,
   Blockchain,
-  Utils
+  Utils,
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,7 @@
 import { TLSSocket } from 'tls';
 import { Socket } from 'json-rpc-tls';
 import { IElectrumRequestBody } from '../';
+import * as bitcoinjs from 'bitcoinjs-lib';
 
 export interface IElectrumRequest extends IElectrumRequestBody {
   method: string;
@@ -13,4 +14,13 @@ class ElectrumUtil {
   }
 }
 
-export { ElectrumUtil };
+class Utils {
+  static addressToScriptHash(address: string, network: any) {
+    const script = bitcoinjs.address.toOutputScript(address, network);
+    const hash = bitcoinjs.crypto.sha256(script);
+    const reversedScriptHash = (Buffer.from(hash.reverse())).toString('hex');
+    return reversedScriptHash
+  }
+}
+
+export { ElectrumUtil, Utils };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -14,13 +14,15 @@ class ElectrumUtil {
   }
 }
 
+/* tslint:disable:max-classes-per-file */
 class Utils {
   static addressToScriptHash(address: string, network: any) {
     const script = bitcoinjs.address.toOutputScript(address, network);
     const hash = bitcoinjs.crypto.sha256(script);
     const reversedScriptHash = (Buffer.from(hash.reverse())).toString('hex');
-    return reversedScriptHash
+    return reversedScriptHash;
   }
 }
+/* tslint:enable:max-classes-per-file */
 
 export { ElectrumUtil, Utils };

--- a/test/blockchain/blockchain.spec.ts
+++ b/test/blockchain/blockchain.spec.ts
@@ -21,7 +21,7 @@ describe('Electrum blockchain method tests', () => {
     const network = bitcoinjs.networks.bitcoin;
     const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
 
-    const response = await Blockchain.ScriptHashSubscribe({
+    const response = await Blockchain.scriptHashSubscribe({
       socket,
       id: 1,
       params: [scripthash]
@@ -37,7 +37,7 @@ describe('Electrum blockchain method tests', () => {
     const network = bitcoinjs.networks.bitcoin;
     const scripthash = Utils.addressToScriptHash('1MaxKapqcv8KVHw1mTzZd23uvntnLABvnB', network);
 
-    const response = await Blockchain.ScriptHashGetHistory({
+    const response = await Blockchain.scriptHashGetHistory({
       socket,
       id: 1,
       params: [scripthash],
@@ -53,7 +53,7 @@ describe('Electrum blockchain method tests', () => {
     const network = bitcoinjs.networks.bitcoin;
     const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
 
-    const response = await Blockchain.ScriptHashGetMempool({
+    const response = await Blockchain.scriptHashGetMempool({
       socket,
       id: 1,
       params: [scripthash],
@@ -68,7 +68,7 @@ describe('Electrum blockchain method tests', () => {
     const network = bitcoinjs.networks.bitcoin;
     const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
 
-    const response = await Blockchain.ScriptHashGetBalance({
+    const response = await Blockchain.scriptHashGetBalance({
       socket,
       id: 1,
       params: [scripthash],
@@ -84,7 +84,7 @@ describe('Electrum blockchain method tests', () => {
     const network = bitcoinjs.networks.bitcoin;
     const scripthash = Utils.addressToScriptHash('12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX', network);
 
-    const response = await Blockchain.ScriptHashListUnspent({
+    const response = await Blockchain.scriptHashListUnspent({
       socket,
       id: 1,
       params: [scripthash],

--- a/test/blockchain/blockchain.spec.ts
+++ b/test/blockchain/blockchain.spec.ts
@@ -1,32 +1,30 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
-import { Blockchain } from '../../src';
+import { Blockchain, Utils } from '../../src';
 import { TestUtils } from '../util';
 
+import * as bitcoinjs from 'bitcoinjs-lib';
+
 describe('Electrum blockchain method tests', () => {
-  it('should subscribe to receive numblocks', async () => {
-    const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.numBlocksSubscribe({ socket, id: 1 });
-    TestUtils.closeSocket(socket);
-    expect(typeof response.result).to.equal('number');
-  });
 
   it('should subscribe to receive headers', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
     const response = await Blockchain.headersSubscribe({ socket, id: 1 });
     TestUtils.closeSocket(socket);
-    expect(response.result).to.have.property('block_height');
-    expect(response.result).to.have.property('version');
-    expect(response.result).to.have.property('bits');
-    expect(response.result).to.have.property('nonce');
+    expect(response.result).to.have.property('height');
+    expect(response.result).to.have.property('hex');
   });
 
   it('should subscribe to receive changes to address', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressSubscribe({
+
+    const network = bitcoinjs.networks.bitcoin;
+    const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
+
+    const response = await Blockchain.ScriptHashSubscribe({
       socket,
       id: 1,
-      params: ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'],
+      params: [scripthash]
     });
     TestUtils.closeSocket(socket);
     expect(response.result).to.not.contain('is not a valid address');
@@ -35,10 +33,14 @@ describe('Electrum blockchain method tests', () => {
 
   it('should get address history', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressGetHistory({
+
+    const network = bitcoinjs.networks.bitcoin;
+    const scripthash = Utils.addressToScriptHash('1MaxKapqcv8KVHw1mTzZd23uvntnLABvnB', network);
+
+    const response = await Blockchain.ScriptHashGetHistory({
       socket,
       id: 1,
-      params: ['1MaxKapqcv8KVHw1mTzZd23uvntnLABvnB'],
+      params: [scripthash],
     });
     TestUtils.closeSocket(socket);
     expect(response.result[0]).have.property('height');
@@ -47,10 +49,14 @@ describe('Electrum blockchain method tests', () => {
 
   it('should get address mempool', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressGetMempool({
+
+    const network = bitcoinjs.networks.bitcoin;
+    const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
+
+    const response = await Blockchain.ScriptHashGetMempool({
       socket,
       id: 1,
-      params: ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'],
+      params: [scripthash],
     });
     TestUtils.closeSocket(socket);
     expect(response.result).be.an('array');
@@ -58,22 +64,14 @@ describe('Electrum blockchain method tests', () => {
 
   it('should get address balance', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressGetBalance({
-      socket,
-      id: 1,
-      params: ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'],
-    });
-    TestUtils.closeSocket(socket);
-    expect(response.result).to.have.property('confirmed');
-    expect(response.result).to.have.property('unconfirmed');
-  });
 
-  it('should get address proof', async () => {
-    const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressGetBalance({
+    const network = bitcoinjs.networks.bitcoin;
+    const scripthash = Utils.addressToScriptHash('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', network);
+
+    const response = await Blockchain.ScriptHashGetBalance({
       socket,
       id: 1,
-      params: ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'],
+      params: [scripthash],
     });
     TestUtils.closeSocket(socket);
     expect(response.result).to.have.property('confirmed');
@@ -82,25 +80,20 @@ describe('Electrum blockchain method tests', () => {
 
   it('should list address unspent', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.addressListUnspent({
+
+    const network = bitcoinjs.networks.bitcoin;
+    const scripthash = Utils.addressToScriptHash('12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX', network);
+
+    const response = await Blockchain.ScriptHashListUnspent({
       socket,
       id: 1,
-      params: ['1MaxKapqcv8KVHw1mTzZd23uvntnLABvnB'],
+      params: [scripthash],
     });
     TestUtils.closeSocket(socket);
     expect(response.result[0]).to.have.property('tx_hash');
     expect(response.result[0]).to.have.property('height');
-  });
-
-  it('should give address given a utxo', async () => {
-    const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
-    const response = await Blockchain.utxoGetAddress({
-      socket,
-      id: 1,
-      params: ['3387418aaddb4927209c5032f515aa442a6587d6e54677f08a03b8fa7789e688', '1'],
-    });
-    TestUtils.closeSocket(socket);
-    expect(response.result).to.equal('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+    expect(response.result[0]).to.have.property('tx_pos');
+    expect(response.result[0]).to.have.property('value');
   });
 
   it('should get block header from block number', async () => {
@@ -108,12 +101,15 @@ describe('Electrum blockchain method tests', () => {
     const response = await Blockchain.blockGetHeader({
       socket,
       id: 1,
-      params: ['0'],
+      params: ['1'],
     });
     TestUtils.closeSocket(socket);
-    expect(response.result).to.have.property('block_height');
-    expect(response.result).to.have.property('merkle_root');
-    expect(response.result.merkle_root).to.equal('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b');
+    // The precise format of a deserialized block header varies by coin, and also potentially by height for the same coin.
+    // Detailed knowledge of the meaning of a block header is neither necessary nor appropriate in the server.
+    // Consequently they were removed from the protocol in version 1.4.
+
+    // Guess you can do: bitcoinjs.Block.fromHex(response.result)
+    expect(response.result).to.equal('010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299');
   });
 
   it('should get merkle tree from transaction hash', async () => {

--- a/test/server/server.spec.ts
+++ b/test/server/server.spec.ts
@@ -8,14 +8,15 @@ describe('Electrum server method tests', () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
     const response = await Server.version({ socket, id: 1 });
     TestUtils.closeSocket(socket);
-    expect(response.result).to.contain('Electrum');
+
+    expect(response.result[0].substring(0, 8)).to.equal('Electrum');
   });
 
   it('should receive banner', async () => {
     const socket = await TestUtils.constructSocket('185.64.116.15', 50002);
     const response = await Server.banner({ socket, id: 1 });
     TestUtils.closeSocket(socket);
-    expect(response.result).to.equal('Welcome to Electrum!');
+    expect(response.result).to.contain('Welcome to this Electrum server!');
   });
 
   it('should receive donation address', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.0.0.tgz#a3014921991066193f6c8e47290d4d598dfd19e6"
 
+"@types/node@10.12.18":
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
 "@types/node@^9.6.5":
   version "9.6.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.5.tgz#ee700810fdf49ac1c399fc5980b7559b3e5a381d"
@@ -54,6 +59,81 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-x@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+bech32@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
+  integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bip174@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bip174/-/bip174-1.0.1.tgz#858a587f9529e22ee9b0572fd884e5783696824d"
+  integrity sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ==
+
+bip32@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.5.tgz#e3808a9e97a880dbafd0f5f09ca4a1e14ee275d2"
+  integrity sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==
+  dependencies:
+    "@types/node" "10.12.18"
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    tiny-secp256k1 "^1.1.3"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
+bip66@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
+  integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
+  integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
+
+bitcoinjs-lib@^5.1.7:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-5.1.7.tgz#dfa023d6ad887eaef8249513d708c9ecd2673a08"
+  integrity sha512-sNlTQuvhaoIjOdIdyENsX74Dlikv7l6AzO0/uZQscuvfBID6aMANoCz1rooCTH5upTV5rKCj4z3BXBmXJxq23g==
+  dependencies:
+    bech32 "^1.1.2"
+    bip174 "^1.0.1"
+    bip32 "^2.0.4"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    bs58check "^2.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.3"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "^1.0.1"
+    randombytes "^2.0.1"
+    tiny-secp256k1 "^1.1.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
+
+bn.js@^4.11.8, bn.js@^4.4.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -61,9 +141,30 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@<3.0.0, bs58check@^2.0.0, bs58check@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
@@ -102,6 +203,14 @@ check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
+cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
@@ -124,6 +233,29 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+create-hash@^1.1.0, create-hash@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.3, create-hmac@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -140,6 +272,19 @@ diff@3.5.0, diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
+elliptic@^6.4.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -151,6 +296,11 @@ esprima@^4.0.0:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -189,9 +339,34 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+hash-base@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  integrity sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+hmac-drbg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -203,6 +378,11 @@ inflight@^1.0.4:
 inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@^2.0.1, inherits@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -222,6 +402,30 @@ json-rpc-tls@^1.2.2:
 make-error@^1.1.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
+merkle-lib@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
+  integrity sha1-grjbrnXieneFOItz+ddyXQ9vMyY=
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
@@ -263,6 +467,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -281,15 +490,50 @@ pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
+pushdata-bitcoin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz#15931d3cd967ade52206f523aa7331aef7d43af7"
+  integrity sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=
+  dependencies:
+    bitcoin-ops "^1.3.0"
+
+randombytes@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
 resolve@^1.3.2:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
     path-parse "^1.0.5"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
 semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 source-map-support@^0.5.3:
   version "0.5.4"
@@ -326,6 +570,17 @@ supports-color@^5.3.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
     has-flag "^3.0.0"
+
+tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.4.tgz#772a7711baaa9e2bffa92708cafadc9d372907a3"
+  integrity sha512-O7NfGzBdBy/jamehZ1ptutZsh2c+9pq2Pu+KPv75+yzk5/Q/6lppQGMUJucHdRGdkeBcAUeLAOdJInEAZgZ53A==
+  dependencies:
+    bindings "^1.3.0"
+    bn.js "^4.11.8"
+    create-hmac "^1.1.7"
+    elliptic "^6.4.0"
+    nan "^2.13.2"
 
 ts-node@^5.0.1:
   version "5.0.1"
@@ -385,9 +640,33 @@ type-detect@^4.0.0:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
+typeforce@^1.11.3, typeforce@^1.11.5:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
+  integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
+
 typescript@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+
+typescript@^3.1.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+varuint-bitcoin@^1.0.4:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
+  integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==
+  dependencies:
+    safe-buffer "^5.1.1"
+
+wif@^2.0.1, wif@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
+  integrity sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=
+  dependencies:
+    bs58check "<3.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Regarding Electrums change from addresses to script hashes

See: https://electrumx.readthedocs.io/en/latest/protocol-changes.html

___________
Circumvents having to `npm publish` the dist folder after manual building, so that its possible to simply require the library from the github url and have it automatically build to the dist folder

You would now be possible to use `npm install --save https://github.com/lacksfish/electrum-api` and have the js files built in the `dist` folder



