### PR TITLE
Refactor of Blockchain and Server by providing method 'request' for other paths

### DIFF
--- a/src/blockchain/index.ts
+++ b/src/blockchain/index.ts
@@ -3,114 +3,57 @@ import { IElectrumRequestBody } from '../';
 
 class Blockchain {
 
-  static async headersSubscribe(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
+  static async request(request: IElectrumRequestBody, path: string) {
+    return ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'blockchain.headers.subscribe',
+      method: path,
       params: request.params || [],
     });
-    return result;
+  }
+
+  static async headersSubscribe(request: IElectrumRequestBody) {
+    return Blockchain.request(request, 'blockchain.headers.subscribe');
   }
 
   static async scriptHashSubscribe(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.scripthash.subscribe',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.scripthash.subscribe');
   }
 
   static async scriptHashGetHistory(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.scripthash.get_history',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.scripthash.get_history');
   }
 
   static async scriptHashGetMempool(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.scripthash.get_mempool',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.scripthash.get_mempool');
   }
 
   static async scriptHashGetBalance(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.scripthash.get_balance',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.scripthash.get_balance');
   }
 
   static async scriptHashListUnspent(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.scripthash.listunspent',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.scripthash.listunspent');
   }
 
   static async blockGetHeader(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.block.header',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.block.header');
   }
 
   static async transactionBroadcast(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.transaction.broadcast',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.transaction.broadcast');
   }
 
   static async transactionGetMerkle(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.transaction.get_merkle',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.transaction.get_merkle');
   }
 
   static async transactionGet(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.transaction.get',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.transaction.get');
   }
 
   static async estimateFee(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'blockchain.estimatefee',
-      params: request.params || [],
-    });
-    return result;
+    return Blockchain.request(request, 'blockchain.estimatefee');
   }
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,44 +3,29 @@ import { IElectrumRequestBody } from '../';
 
 class Server {
 
-  static async version(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
+  static async request(request: IElectrumRequestBody, path: string) {
+    return ElectrumUtil.makeRequest({
       socket: request.socket,
       id: request.id,
-      method: 'server.version',
+      method: path,
       params: request.params || [],
     });
-    return result;
+  }
+
+  static async version(request: IElectrumRequestBody) {
+    return Server.request(request, 'server.version');
   }
 
   static async banner(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'server.banner',
-      params: request.params || [],
-    });
-    return result;
+    return Server.request(request, 'server.banner');
   }
 
   static async donationAddress(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'server.donation_address',
-      params: request.params || [],
-    });
-    return result;
+    return Server.request(request, 'server.donation_address');
   }
 
   static async peersSubscribe(request: IElectrumRequestBody) {
-    const result = await ElectrumUtil.makeRequest({
-      socket: request.socket,
-      id: request.id,
-      method: 'server.peers.subscribe',
-      params: request.params || [],
-    });
-    return result;
+    return Server.request(request, 'server.peers.subscribe');
   }
 }
 


### PR DESCRIPTION
The idea being that the `request` function can be used to provide a path which is currently not available through a designated method. (for example the [masternode](https://electrumx.readthedocs.io/en/latest/protocol-methods.html#masternode-methods-dash-and-compatible-coins) paths and other missing ones)